### PR TITLE
Allow 1-second of clock drift in claim renewal test

### DIFF
--- a/apps/gust/test/run/claim/repo_test.exs
+++ b/apps/gust/test/run/claim/repo_test.exs
@@ -39,7 +39,7 @@ defmodule Run.Claim.RepoTest do
       assert %Flows.Run{id: ^run_id, claim_expires_at: new_expiration_date} =
                Claim.renew_run(run.id, run.claim_token)
 
-      assert DateTime.diff(now, new_expiration_date) == -lease_seconds
+      assert DateTime.diff(now, new_expiration_date) in [-(lease_seconds + 1), -lease_seconds]
     end
   end
 


### PR DESCRIPTION
<img width="655" height="280" alt="gust_test1" src="https://github.com/user-attachments/assets/85c888ab-2887-4e19-a63d-1ff7d291861a" />


This was happening locally on my laptop when running `mix test` or `mix test test/run/claim/repo_test.exs:42`. If it's not failing in CI, can understand if you don't want to fix, and please feel free to close this if that's the case.

