### PR TITLE
feat: Add params field on Run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ dags/
 
 .envrc
 .env
+docker-compose.yml
 .env.test
 .env.dev
 

--- a/apps/gust/lib/gust/dag/task_worker/adapters/elixir.ex
+++ b/apps/gust/lib/gust/dag/task_worker/adapters/elixir.ex
@@ -10,7 +10,8 @@ defmodule Gust.DAG.TaskWorker.Adapters.Elixir do
         %{task: task, dag_def: dag_def, stage_pid: stage_pid, opts: opts} = state
       ) do
     fun_name = String.to_atom(task.name)
-    args = [%{run_id: task.run_id}]
+    run = Gust.Flows.get_run!(task.run_id)
+    args = [%{run_id: task.run_id, params: run.params}]
 
     Logger.set_task(task.id, task.attempt)
 

--- a/apps/gust/lib/gust/flows/run.ex
+++ b/apps/gust/lib/gust/flows/run.ex
@@ -11,6 +11,7 @@ defmodule Gust.Flows.Run do
       values: [:created, :running, :succeeded, :failed, :enqueued],
       default: :created
 
+    field :params, :map, default: %{}
     field :claimed_by, :string
     field :claim_expires_at, :utc_datetime_usec
     field :claim_token, Ecto.UUID
@@ -24,6 +25,7 @@ defmodule Gust.Flows.Run do
           id: integer() | nil,
           dag_id: integer() | nil,
           status: :created | :running | :succeeded | :failed | :enqueued,
+          params: map(),
           tasks: [Gust.Flows.Task.t()] | Ecto.Association.NotLoaded.t(),
           dag: Gust.Flows.Dag.t() | Ecto.Association.NotLoaded.t(),
           inserted_at: DateTime.t() | nil,
@@ -33,14 +35,22 @@ defmodule Gust.Flows.Run do
   @doc false
   def changeset(run, attrs) do
     run
-    |> cast(attrs, [:dag_id, :status, :claim_expires_at, :claim_token])
+    |> cast(attrs, [:dag_id, :status, :params, :claim_expires_at, :claim_token])
     |> validate_required([:dag_id, :status])
   end
 
   @doc false
   def test_changeset(run, attrs) do
     run
-    |> cast(attrs, [:dag_id, :status, :inserted_at, :claim_token, :claim_expires_at, :claimed_by])
+    |> cast(attrs, [
+      :dag_id,
+      :status,
+      :params,
+      :inserted_at,
+      :claim_token,
+      :claim_expires_at,
+      :claimed_by
+    ])
     |> validate_required([:dag_id, :status])
   end
 end

--- a/apps/gust/priv/repo/migrations/20260522122508_add_params_to_gust_runs.exs
+++ b/apps/gust/priv/repo/migrations/20260522122508_add_params_to_gust_runs.exs
@@ -1,0 +1,9 @@
+defmodule Gust.Repo.Migrations.AddParamsToGustRuns do
+  use Ecto.Migration
+
+  def change do
+    alter table(:gust_runs) do
+      add :params, :map, default: %{}, null: false
+    end
+  end
+end

--- a/apps/gust/test/flows_test.exs
+++ b/apps/gust/test/flows_test.exs
@@ -163,6 +163,24 @@ defmodule FlowsTest do
       assert Ecto.assoc_loaded?(run.tasks)
       assert is_list(run.tasks)
     end
+
+    test "create_run/1 defaults params to empty map" do
+      dag = dag_fixture(%{name: "default_params"})
+
+      assert {:ok, %Run{} = run} = Flows.create_run(%{dag_id: dag.id})
+      assert run.params == %{}
+    end
+
+    test "create_run/1 with params persists them" do
+      dag = dag_fixture(%{name: "with_params"})
+      params = %{"brand" => "ford", "year" => 2024}
+
+      assert {:ok, %Run{} = run} = Flows.create_run(%{dag_id: dag.id, params: params})
+      assert run.params == params
+
+      fetched = Flows.get_run!(run.id)
+      assert fetched.params == params
+    end
   end
 
   describe "log" do

--- a/apps/gust_web/lib/gust_web/live/dag_live/dashboard.html.heex
+++ b/apps/gust_web/lib/gust_web/live/dag_live/dashboard.html.heex
@@ -186,6 +186,19 @@
       </div>
     </section>
 
+    <section :if={map_size(@selected_run.params || %{}) > 0} class="dag-card__body">
+      <h4 class="text-sm font-semibold text-slate-700">Params</h4>
+      <div class="overflow-x-auto overflow-y-auto max-h-96 mt-2">
+        <pre
+          id="run-params"
+          data-testid="run-params"
+          class="language-json rounded-md overflow-x-auto"
+        >
+<%= pretty_json!(@selected_run.params) %>
+        </pre>
+      </div>
+    </section>
+
     <section :if={@selected_task && map_size(@selected_task.error) > 0} class="dag-card__body">
       <h4 class="text-sm font-semibold text-rose-600">Error</h4>
       <div class="alert overflow-auto mt-2">

--- a/apps/gust_web/test/gust_web/live/dag_live_dashboard_test.exs
+++ b/apps/gust_web/test/gust_web/live/dag_live_dashboard_test.exs
@@ -685,5 +685,34 @@ defmodule GustWeb.DagLiveDashboardTest do
 
       assert triggered_flash =~ "Run #{last_run.id} triggered"
     end
+
+    test "display run params when present", %{
+      conn: conn,
+      dag: dag
+    } do
+      params = %{"brand" => "ford", "model" => "ranger"}
+
+      run_with_params =
+        run_fixture(%{dag_id: dag.id, params: params})
+
+      {:ok, dashboard_live, _html} =
+        live(conn, ~g"/dags/#{dag.name}/dashboard?run_id=#{run_with_params.id}")
+
+      assert has_element?(dashboard_live, "#run-params")
+      params_html = dashboard_live |> element("#run-params") |> render()
+      assert params_html =~ "ford"
+      assert params_html =~ "ranger"
+    end
+
+    test "hide run params section when params are empty", %{
+      conn: conn,
+      dag: dag,
+      run: run
+    } do
+      {:ok, dashboard_live, _html} =
+        live(conn, ~g"/dags/#{dag.name}/dashboard?run_id=#{run.id}")
+
+      refute has_element?(dashboard_live, "#run-params")
+    end
   end
 end

--- a/examples/dags/params_example.ex
+++ b/examples/dags/params_example.ex
@@ -1,0 +1,40 @@
+defmodule ParamsExample do
+  @moduledoc """
+  Example DAG demonstrating two ways to access run params.
+
+  Trigger with:
+
+      {:ok, run} = Gust.Flows.create_run(%{
+        dag_id: dag.id,
+        params: %{"greeting" => "Hello", "name" => "World"}
+      })
+
+  """
+  use Gust.DSL
+  require Logger
+  alias Gust.Flows
+
+  # Option 1: access params directly via ctx pattern matching
+  task :via_ctx, downstream: [:greet], save: true, ctx: %{params: params} do
+    greeting = Map.get(params, "greeting", "Hi")
+    Logger.info("[via_ctx] greeting=#{greeting}")
+    %{greeting: greeting}
+  end
+
+  # Option 2: access params by fetching the run manually
+  task :via_run, downstream: [:greet], save: true, ctx: %{run_id: run_id} do
+    run = Flows.get_run!(run_id)
+    name = Map.get(run.params, "name", "Gust")
+    Logger.info("[via_run] name=#{name}")
+    %{name: name}
+  end
+
+  # Combine results from both upstream tasks
+  task :greet, ctx: %{run_id: run_id} do
+    %{"greeting" => greeting} = Flows.get_task_by_name_run("via_ctx", run_id).result
+    %{"name" => name} = Flows.get_task_by_name_run("via_run", run_id).result
+
+    message = "#{greeting}, #{name}!"
+    Logger.info("[greet] #{message}")
+  end
+end


### PR DESCRIPTION
This commit adds a 'params' JSONB field to the Gust.Flows.Run schema to allow passing input parameters to DAG runs. It also injects these params into the 'ctx' accessible by tasks, and renders the selected run params in the dashboard UI. An example DAG is provided demonstrating its usage. Resolves #58.